### PR TITLE
Loosen dependency restrictions to allow usage in rails 4 apps

### DIFF
--- a/chartjs-ror.gemspec
+++ b/chartjs-ror.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'rails', '~> 3.1'
+  gem.add_dependency 'rails', '>= 3.1'
   gem.add_development_dependency 'rake'
 end

--- a/lib/chartjs/version.rb
+++ b/lib/chartjs/version.rb
@@ -1,3 +1,3 @@
 module Chartjs
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end


### PR DESCRIPTION
Currently the gemspec restricts usage to apps running on rails 3.1 but still rails 3. This will allow usage in rails 3.1 or greater. I did not see anything in the codebase that would be a cause of concern.
