### PR TITLE
Fix errors when using turbolinks and ajax

### DIFF
--- a/lib/chartjs/chart_helpers.rb
+++ b/lib/chartjs/chart_helpers.rb
@@ -57,7 +57,7 @@ module Chartjs
           if (window.addEventListener) {
             window.addEventListener("load", initChart, false);
             document.addEventListener("page:load", initChart, false);
-            document.addEventListener("ajax:load", initChart, false);
+            document.addEventListener("ajax:success", initChart, false);
           }
           /* IE */
           else if (window.attachEvent) {

--- a/lib/chartjs/chart_helpers.rb
+++ b/lib/chartjs/chart_helpers.rb
@@ -36,12 +36,16 @@ module Chartjs
       script = javascript_tag do
         <<-END.squish.html_safe
         (function() {
+        
           var initChart = function() {
             var data = #{data.to_json};
             var opts = #{options.to_json};
             if (!("animation" in opts)) {
               opts["animation"] = (typeof Modernizr == "undefined") || Modernizr.canvas;
             }
+            
+            chart && chart.destroy();
+            
             var canvas = document.getElementById(#{element_id.to_json});
             var ctx = canvas.getContext('2d');
             var chart = new Chart(ctx).#{klass}(data, opts);
@@ -53,6 +57,7 @@ module Chartjs
           if (window.addEventListener) {
             window.addEventListener("load", initChart, false);
             document.addEventListener("page:load", initChart, false);
+            initChart();
           }
           /* IE */
           else if (window.attachEvent) {

--- a/lib/chartjs/chart_helpers.rb
+++ b/lib/chartjs/chart_helpers.rb
@@ -35,7 +35,7 @@ module Chartjs
 
       script = javascript_tag do
         <<-END.squish.html_safe
-        $(function() {
+        (function() {
         
           var initChart = function() {
             var data = #{data.to_json};
@@ -44,7 +44,7 @@ module Chartjs
               opts["animation"] = (typeof Modernizr == "undefined") || Modernizr.canvas;
             }
             
-          
+            canvas && canvas.destroy();
             
             var canvas = document.getElementById(#{element_id.to_json});
             var ctx = canvas.getContext('2d');
@@ -53,18 +53,9 @@ module Chartjs
 
             #{legend if generate_legend}
           };
-           initChart();
-          /* W3C standard */
-          if (window.addEventListener) {
-           window.addEventListener("load", initChart, false);
-            document.addEventListener("page:load", initChart, false);
-           
-          }
-          /* IE */
-          else if (window.attachEvent) {
-            window.attachEvent("onload", initChart);
-            document.attachEvent("page:load", initChart);
-          }
+          
+          initChart();
+         
         })();
         END
       end

--- a/lib/chartjs/chart_helpers.rb
+++ b/lib/chartjs/chart_helpers.rb
@@ -57,7 +57,7 @@ module Chartjs
           if (window.addEventListener) {
             window.addEventListener("load", initChart, false);
             document.addEventListener("page:load", initChart, false);
-            initChart();
+            document.addEventListener("ajax:load", initChart, false);
           }
           /* IE */
           else if (window.attachEvent) {

--- a/lib/chartjs/chart_helpers.rb
+++ b/lib/chartjs/chart_helpers.rb
@@ -44,7 +44,7 @@ module Chartjs
               opts["animation"] = (typeof Modernizr == "undefined") || Modernizr.canvas;
             }
             
-           // chart && chart.destroy();
+          
             
             var canvas = document.getElementById(#{element_id.to_json});
             var ctx = canvas.getContext('2d');

--- a/lib/chartjs/chart_helpers.rb
+++ b/lib/chartjs/chart_helpers.rb
@@ -44,7 +44,7 @@ module Chartjs
               opts["animation"] = (typeof Modernizr == "undefined") || Modernizr.canvas;
             }
             
-            chart && chart.destroy();
+            //chart && chart.destroy();
             
             var canvas = document.getElementById(#{element_id.to_json});
             var ctx = canvas.getContext('2d');

--- a/lib/chartjs/chart_helpers.rb
+++ b/lib/chartjs/chart_helpers.rb
@@ -55,9 +55,9 @@ module Chartjs
           };
           /* W3C standard */
           if (window.addEventListener) {
-            window.addEventListener("load", initChart, false);
-            document.addEventListener("page:load", initChart, false);
-            $(document).on('ajaxSuccess', function() { initChart } )
+          //  window.addEventListener("load", initChart, false);
+          //  document.addEventListener("page:load", initChart, false);
+            initChart();
           }
           /* IE */
           else if (window.attachEvent) {

--- a/lib/chartjs/chart_helpers.rb
+++ b/lib/chartjs/chart_helpers.rb
@@ -55,8 +55,8 @@ module Chartjs
           };
           /* W3C standard */
           if (window.addEventListener) {
-          /*  window.addEventListener("load", initChart, false);
-            document.addEventListener("page:load", initChart, false);*/
+           window.addEventListener("load", initChart, false);
+            document.addEventListener("page:load", initChart, false);
             initChart();
           }
           /* IE */

--- a/lib/chartjs/chart_helpers.rb
+++ b/lib/chartjs/chart_helpers.rb
@@ -35,7 +35,7 @@ module Chartjs
 
       script = javascript_tag do
         <<-END.squish.html_safe
-        (function() {
+        $(function() {
         
           var initChart = function() {
             var data = #{data.to_json};
@@ -57,7 +57,7 @@ module Chartjs
           if (window.addEventListener) {
             window.addEventListener("load", initChart, false);
             document.addEventListener("page:load", initChart, false);
-            document.addEventListener("ajaxSuccess", initChart, false);
+            $(document).on('ajaxSuccess', function() { initChart } )
           }
           /* IE */
           else if (window.attachEvent) {

--- a/lib/chartjs/chart_helpers.rb
+++ b/lib/chartjs/chart_helpers.rb
@@ -44,7 +44,7 @@ module Chartjs
               opts["animation"] = (typeof Modernizr == "undefined") || Modernizr.canvas;
             }
             
-            //chart && chart.destroy();
+            chart && chart.destroy();
             
             var canvas = document.getElementById(#{element_id.to_json});
             var ctx = canvas.getContext('2d');

--- a/lib/chartjs/chart_helpers.rb
+++ b/lib/chartjs/chart_helpers.rb
@@ -44,7 +44,7 @@ module Chartjs
               opts["animation"] = (typeof Modernizr == "undefined") || Modernizr.canvas;
             }
             
-            chart && chart.destroy();
+           // chart && chart.destroy();
             
             var canvas = document.getElementById(#{element_id.to_json});
             var ctx = canvas.getContext('2d');
@@ -53,11 +53,12 @@ module Chartjs
 
             #{legend if generate_legend}
           };
+           initChart();
           /* W3C standard */
           if (window.addEventListener) {
            window.addEventListener("load", initChart, false);
             document.addEventListener("page:load", initChart, false);
-            initChart();
+           
           }
           /* IE */
           else if (window.attachEvent) {

--- a/lib/chartjs/chart_helpers.rb
+++ b/lib/chartjs/chart_helpers.rb
@@ -57,7 +57,7 @@ module Chartjs
           if (window.addEventListener) {
             window.addEventListener("load", initChart, false);
             document.addEventListener("page:load", initChart, false);
-            document.addEventListener("ajax:success", initChart, false);
+            document.addEventListener("ajaxSuccess", initChart, false);
           }
           /* IE */
           else if (window.attachEvent) {

--- a/lib/chartjs/chart_helpers.rb
+++ b/lib/chartjs/chart_helpers.rb
@@ -55,8 +55,8 @@ module Chartjs
           };
           /* W3C standard */
           if (window.addEventListener) {
-          //  window.addEventListener("load", initChart, false);
-          //  document.addEventListener("page:load", initChart, false);
+          /*  window.addEventListener("load", initChart, false);
+            document.addEventListener("page:load", initChart, false);*/
             initChart();
           }
           /* IE */


### PR DESCRIPTION
This fixed some errors i was getting:

`canvas && canvas.destroy();`

Prevented a glitch when hovering the chart using tubolinks, it was rendering parts of the previous chart. So, if canvas exists, it is destroyed before creating a new one.

`initChart();`

Simply calling the initChart method, not binding it to any dom event, solved the ajax issue i was having, and still work with regular page loading.