### PR TITLE
Add namespacing to the view helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ Each chart type has a corresponding helper for your views.  The helper methods t
 
 
 ```erb
-<%= line_chart     data, options %>
-<%= bar_chart      data, options %>
-<%= radar_chart    data, options %>
-<%= polar_chart    data, options %>
-<%= pie_chart      data, options %>
-<%= doughnut_chart data, options %>
+<%= chartjs_line_chart     	data, options %>
+<%= chartjs_bar_chart      	data, options %>
+<%= chartjs_radar_chart    	data, options %>
+<%= chartjs_polar_area_chart    data, options %>
+<%= chartjs_pie_chart      	data, options %>
+<%= chartjs_doughnut_chart 	data, options %>
 ```
 
 For example, to render a [line chart][linechart] in Javascript:

--- a/lib/chartjs/chart_helpers.rb
+++ b/lib/chartjs/chart_helpers.rb
@@ -3,7 +3,7 @@ module Chartjs
 
     %w[ Line Bar Radar PolarArea Pie Doughnut ].each do |type|
       camel_type = type.gsub(/(\w)([A-Z])/, '\1_\2').downcase
-      define_method "#{camel_type}_chart" do |data, options = {}|    # def polar_area_chart(data, options = {})
+      define_method "chartjs_#{camel_type}_chart" do |data, options = {}|    # def polar_area_chart(data, options = {})
         chart type, data, options                                    #   chart 'PolarArea', data, options
       end                                                            # end
     end


### PR DESCRIPTION
Other charting libraries may exist within the same app that also may use the same helpers.  By namespacing the helpers, the two libraries would not clobber each other.