### PR TITLE
fix passing functions for onAnimationComplete and onAnimationProgress

### DIFF
--- a/lib/chartjs/chart_helpers.rb
+++ b/lib/chartjs/chart_helpers.rb
@@ -40,7 +40,9 @@ module Chartjs
             window.Chart && window.Chart[#{element_id.to_json}] && window.Chart[#{element_id.to_json}].destroy();
 
             var data = #{data.to_json};
-            var opts = #{options.to_json};
+            var opts = #{options.reject{|o| ['onAnimationComplete', 'onAnimationProgress'].include?(o)}.to_json};
+            opts["onAnimationComplete"] = #{options[:onAnimationComplete] || 'function(){}'};
+            opts["onAnimationProgess"] = #{options[:onAnimationProgress] || 'function(){}'};
             if (!("animation" in opts)) {
               opts["animation"] = (typeof Modernizr == "undefined") || Modernizr.canvas;
             }


### PR DESCRIPTION
using to_json on the options breaks js functions passed through for onAnimationComplete and onAnimationProgress. so don't to_json them, pass through directly.

deals with issue #11 