### PR TITLE
Fix issues with Turbolinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,14 +165,7 @@ You can put anything in the `options` hash that Chart.js recognises.  It also su
       legendHolder.innerHTML = legend;
       canvas.parentNode.insertBefore(legendHolder.firstChild, canvas.nextSibling);
     };
-    if (window.addEventListener) {
-      window.addEventListener("load", initChart, false);
-      document.addEventListener("page:load", initChart, false);
-    }
-    else if (window.attachEvent) {
-      window.attachEvent("onload", initChart);
-      document.attachEvent("page:load", initChart);
-    }
+	initChart();
   })();
 </script>
 ```

--- a/lib/chartjs/chart_helpers.rb
+++ b/lib/chartjs/chart_helpers.rb
@@ -55,16 +55,7 @@ module Chartjs
 
             #{legend if generate_legend}
           };
-          /* W3C standard */
-          if (window.addEventListener) {
-            window.addEventListener("load", initChart, false);
-            document.addEventListener("page:load", initChart, false);
-          }
-          /* IE */
-          else if (window.attachEvent) {
-            window.attachEvent("onload", initChart);
-            document.attachEvent("page:load", initChart);
-          }
+          initChart();
         })();
         END
       end


### PR DESCRIPTION
There are two issues using the `chart` helper in conjunction with Turbolinks:

1. On using browser's back button, Turbolinks restores the page from a cache and triggers a `page:restore` event instead of `page:load`. Because there is no listener for this event, the charts on this pages are missing. Maybe this could be fixed by adding a listener for `page:restore` - but wait and look at the next issue.

2. Adding event listeners seems not right to me (disclaimer: I'm **not** a JS expert): If the user changes to a page without charts, the added listeners still exists and are triggered again - but fail because the chart does not exist in the DOM anymore. In the browsers JS console we see JS error on every page change.

This PR fixes both issues by executing `initChart()` without event listener (like proposed by @glundgren in #5). Because #5 is some kind of stale, I open this one. What do you think?

The right way of initializing a chart is asked in nnnick/Chart.js#929, but there is still no anwer.