### PR TITLE
Adds CSP nonce to inline JavaScript

### DIFF
--- a/lib/chartjs/chart_helpers.rb
+++ b/lib/chartjs/chart_helpers.rb
@@ -37,7 +37,7 @@ module Chartjs
 
       canvas = content_tag :canvas, '', id: element_id, class: css_class, width: width, height: height
 
-      script = javascript_tag do
+      script = javascript_tag(nonce: true) do
         <<-END.squish.html_safe
         (function() {
           var initChart = function() {


### PR DESCRIPTION
Adds a nonce="..." attribute into the script tag. This allows Charts to be rendered whilst using Content Security Policy HTTP headers.

Fixes #45 