### PR TITLE
#41: Add container element to fix behaviour in responsive mode

### DIFF
--- a/lib/chartjs/chart_helpers.rb
+++ b/lib/chartjs/chart_helpers.rb
@@ -36,6 +36,7 @@ module Chartjs
       height     = opts.delete(:height) || '400'
 
       canvas = content_tag :canvas, '', id: element_id, class: css_class, width: width, height: height
+      container = content_tag :div, canvas, id: element_id + "-container", class: css_class, width: width, height: height
 
       script = javascript_tag(nonce: true) do
         <<-END.squish.html_safe
@@ -67,7 +68,7 @@ module Chartjs
         END
       end
 
-      canvas + script
+      container + script
     end
 
     # polar_area -> polarArea


### PR DESCRIPTION
As mentioned in #41, the width and height attributes work poorly without a container element around the canvas, this is also mentioned in https://www.chartjs.org/docs/latest/general/responsive.html#important-note. This PR makes chartjs-ror create an container element for the canvas to fix this behaviour.